### PR TITLE
Update socket.io client to 1.0.0

### DIFF
--- a/ATMobileAnalytics/SmartTracker/build.gradle
+++ b/ATMobileAnalytics/SmartTracker/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     compileOnly 'com.android.support:appcompat-v7:26.1.0'
     compileOnly 'com.google.android.gms:play-services-ads:11.8.0'
-    compileOnly('io.socket:socket.io-client:0.8.3') {
+    compileOnly('io.socket:socket.io-client:1.0.0') {
         // excluding org.json which is provided by Android
         exclude group: 'org.json', module: 'json'
     }


### PR DESCRIPTION
This commit updates socket.io client to 1.0.0 to fix issues with
Lollipop devices from previous versions of socket.io in which
they used the Android framework's OkHttp version which had a cache issue
causing it to randomly crash and corrupt cache on devices running Android
5.x.

All tests in Tracker and SmartTracker module pass after the dependency update.