### PR TITLE
Make sure hits never get stored to database if OfflineMode is set to never

### DIFF
--- a/ATMobileAnalytics/Tracker/src/main/java/com/atinternet/tracker/Core.java
+++ b/ATMobileAnalytics/Tracker/src/main/java/com/atinternet/tracker/Core.java
@@ -752,7 +752,8 @@ class Sender implements Runnable {
             return;
         }
 
-        if (!hit.isOffline() && storage.getCountOfflineHits() > 0) {
+        // For offlineModes "required" and "always", skip sending hit if sendOfflineHits left hits in the database (e.g. server error,...)
+        if (tracker.getOfflineMode() != Tracker.OfflineMode.never && !hit.isOffline() && storage.getCountOfflineHits() > 0) {
             saveHitDatabase(hit);
             return;
         }


### PR DESCRIPTION
This PR fixes https://github.com/at-internet/atinternet-android-sdk/issues/19. 

Between SDK version 2.12.0 up to 2.13.1 hits were erroneously stored to the database even if `storage` was configured to `never`. This change guards the `saveHitDatabase()` call in case offline mode was configured with `never`. After this change, new hits sent from apps with previously stored offline hits will be sent to the backend again, but all offline hits stay on the phone until the developer decides to call `tracker.Offline().dispatch()`.